### PR TITLE
Update met.no API call to version 1.3

### DIFF
--- a/sdk-parsers/RMParserFramework/parsers/met-no-parser.py
+++ b/sdk-parsers/RMParserFramework/parsers/met-no-parser.py
@@ -37,7 +37,7 @@ class METNO(RMParser):
 
     def perform(self):
         s = self.settings
-        URL = "http://api.met.no/weatherapi/locationforecastlts/1.2/"
+        URL = "http://api.met.no/weatherapi/locationforecastlts/1.3/"
         URLParams = [("lat", s.location.latitude),
                   ("lon", s.location.longitude),
                   ("msl", int(round(s.location.elevation)))]


### PR DESCRIPTION
The met.no api v1.2 is end-of-life and stopped working. Change to v1.3 fixed the issue.
See http://api.met.no/weatherapi/locationforecastlts/1.3/documentation