### PR TITLE
Update purpleair-parser

### DIFF
--- a/version-metadata.json
+++ b/version-metadata.json
@@ -71,7 +71,7 @@
       "instructions": ""
     },
     "sdk-parsers/RMParserFramework/parsers/purpleair-parser.py": {
-      "version": "1.03",
+      "version": "2.00",
       "author": "Mike Edmunds <medmunds@gmail.com>",
       "name": "PurpleAir Parser",
       "description": "Obtain temperature from PurpleAir sensor",


### PR DESCRIPTION
Switch to new PurpleAir API.
(PurpleAir discontinued the previous json data API in May 2022.)

This drops support for older RainMachine models like the Mini-8. 
(Their latest available firmware includes outdated https root certificates, 
so cannot communicate successfully with PurpleAir's API servers.)

Sync with medmunds/rainmachine-weather-purpleair@v2.01.